### PR TITLE
Cleaned up the TOC-s for the relevant audio tests

### DIFF
--- a/audiobooks/manifest_processing/tests/test_a4.2.04.html
+++ b/audiobooks/manifest_processing/tests/test_a4.2.04.html
@@ -53,8 +53,11 @@
 </head>
 <body>
     <p>This is just a fake entry point with a fake TOC.</p>
-    <ol role="doc-toc">
-        <li>Table of content 1</li>
-    </ol>
+    <nav role="doc-toc">
+      <h2>Minimal, Embedded Table of content</h2>
+      <ol role="doc-toc">
+          <li><a href="http://www.archive.org/download/flatland_rg_librivox/flatland_1_abbott.mp3">Flatland 1</li>
+      </ol>
+    </nav>
 </body>
 </html>

--- a/audiobooks/manifest_processing/tests/toc.html
+++ b/audiobooks/manifest_processing/tests/toc.html
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
 <html>
+
 <head>
-    <title>Entry point with linked manifest, with a local TOC</title>
-    <link rel="publication" href="link_4.2.02.jsonld" />
+    <title>Minimal TOC</title>
 </head>
+
 <body>
-    <p>This is just a fake entry point with a fake TOC.</p>
+    <p>This is just a fake TOC.</p>
     <nav role="doc-toc">
         <h2>Minimal Table of content</h2>
         <ol role="doc-toc">

--- a/publication_manifest/toc_processing/tests/c2.branches.08.html
+++ b/publication_manifest/toc_processing/tests/c2.branches.08.html
@@ -57,15 +57,15 @@
 			<h2>Contents</h2>
 			<ul>
 				<li>
-					<a href="s1">Section 1</a>
+					<a href="#s1">Section 1</a>
 					<ul>
 						<li>
-							<a href="s11">Section 1.1</a>
+							<a href="#s11">Section 1.1</a>
 						</li>
 					</ul>
 					<ul>
 						<li>
-							<a href="s11">Wrong Link</a>
+							<a href="#s11">Wrong Link</a>
 						</li>
 					</ul>
 				</li>

--- a/publication_manifest/toc_processing/tests/c2.ignored.03.html
+++ b/publication_manifest/toc_processing/tests/c2.ignored.03.html
@@ -59,7 +59,7 @@
 			<h2>Contents</h2>
 				<ol>
 					<li>
-						<a href="p1">Part 1</a>
+						<a href="#p1">Part 1</a>
 						<ol>
 							<li>Chapter 1</li>
 							<li><p>Chapter 2</p></li>
@@ -80,7 +80,7 @@
    "entries": [
       {
          "name": "Part 1",
-         "url": "p1",
+         "url": "#p1",
          "type": null,
          "rel": null,
          "entries": null

--- a/publication_manifest/toc_processing/tests/c2.ignored.04.html
+++ b/publication_manifest/toc_processing/tests/c2.ignored.04.html
@@ -59,7 +59,7 @@
 			<h2>Contents</h2>
 				<ol>
 					<li>
-						<a href="p1">Part 1</a>
+						<a href="#p1">Part 1</a>
 						<ol>
 							<li><a href="#c1">Chapter 1</a></li>
 							<li>Chapter 2</li>
@@ -88,7 +88,7 @@
    "entries": [
       {
          "name": "Part 1",
-         "url": "p1",
+         "url": "#p1",
          "type": null,
          "rel": null,
          "entries": [

--- a/publication_manifest/toc_processing/tests/s4.8.1.3.04.html
+++ b/publication_manifest/toc_processing/tests/s4.8.1.3.04.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 		<title>Multiple table of contents - No reference</title>
-		<link rel="publication" href="s4813-01/publication.jsonld">
+		<link rel="publication" href="s4813-04/publication.jsonld">
 		<link rel="stylesheet" href="css/basic.css">
 	</head>
 	<body>


### PR DESCRIPTION
The current ToC related audio tests, when around, were all just fakes, which distorted the testing. Though minimal, at least they are syntactically o.k. insofar as the requirements to locate the ToC-s are covered. For more elaborate ToC tests see the dedicated test suite