### PR TITLE
Pep related changes 199

### DIFF
--- a/publication_manifest/manifest_processing/reports/PubManifest.json
+++ b/publication_manifest/manifest_processing/reports/PubManifest.json
@@ -70,5 +70,7 @@
     "m6.03"        : true,
     "m6.04"        : true,
     "m6.05"        : true,
-    "m6.06"        : true
+    "m6.06"        : true,
+    "m6.07"        : true,
+    "m6.08"        : true
 }

--- a/publication_manifest/manifest_processing/tests/index.json
+++ b/publication_manifest/manifest_processing/tests/index.json
@@ -640,6 +640,14 @@
                     "actions": "An application-dependent name should be added",
                     "errors": "Validation error on a missing default title",
                     "media-type": "text/html"
+                },
+                {
+                    "id": "m6.07",
+                    "format": "html",
+                    "description": "A single document publication, where the reading order uses an empty string to refer to itself.",
+                    "actions": "Display the manifest",
+                    "errors": "none",
+                    "media-type": "text/html"
                 }
             ]
         }

--- a/publication_manifest/manifest_processing/tests/index.json
+++ b/publication_manifest/manifest_processing/tests/index.json
@@ -407,9 +407,9 @@
                 },
                 {
                     "id": "m4.7.2.1.03",
-                    "description": "A missing 'readingOrder' is replaced by a default",
-                    "actions": "A 'readingOrder' is added with a single link set to the HTML Nodes Document.URL. If none provided, validation error",
-                    "errors": "Validation error on invalid URL, and a validation error on removing the corresponding Linked Resource",
+                    "description": "A missing 'readingOrder'",
+                    "actions": "Without a referring document to be added to the list, the 'readingOrder' is empty, which is a fatal error",
+                    "errors": "Fatal error",
                     "media-type": "application/ld+json"
                 },
                 {
@@ -644,12 +644,20 @@
                 {
                     "id": "m6.07",
                     "format": "html",
-                    "description": "A single document publication, where the reading order uses an empty string to refer to itself.",
+                    "description": "The URL of the Primary Entry Point MUST be in either the resources' list or the reading order",
                     "actions": "Display the manifest",
+                    "errors": "Validation error on the PEP URL missing from both the resources and the reading order.",
+                    "media-type": "text/html"
+                },
+                {
+                    "id": "m6.08",
+                    "format": "html",
+                    "description": "If the 'readingOrder' is empty, the URL of the Primary Entry Page is used as a default",
+                    "actions": "The external manifest should be processed and generated with the reading order set to the entry point's URL. The value should also be present in the 'uniqueResources' array.",
                     "errors": "none",
                     "media-type": "text/html"
                 }
-            ]
+           ]
         }
     ]
 }

--- a/publication_manifest/manifest_processing/tests/link6.08.jsonld
+++ b/publication_manifest/manifest_processing/tests/link6.08.jsonld
@@ -4,11 +4,5 @@
     "name" : "My Wonderful Book",
     "id" : "urn:isbn:1234567890",
     "url": "https://example.org/book",
-    "conformsTo": "https://www.w3.org/TR/pub-manifest/",
-    "readingOrder": [
-        "chapter1.html"
-    ],
-    "resources": [
-        "test_m6.01.html"
-    ]
+    "conformsTo": "https://www.w3.org/TR/pub-manifest/"
 }

--- a/publication_manifest/manifest_processing/tests/test_m6.02.html
+++ b/publication_manifest/manifest_processing/tests/test_m6.02.html
@@ -13,6 +13,9 @@
             "conformsTo": "https://www.w3.org/TR/pub-manifest/",
             "readingOrder": [
                 "chapter1.html"
+            ],
+            "resources": [
+                "test_m6.02.html"
             ]
         }
     </script>

--- a/publication_manifest/manifest_processing/tests/test_m6.03.html
+++ b/publication_manifest/manifest_processing/tests/test_m6.03.html
@@ -12,6 +12,9 @@
             "conformsTo": "https://www.w3.org/TR/pub-manifest/",
             "readingOrder": [
                 "chapter1.html"
+            ],
+            "resources": [
+                "test_m6.02.html"
             ]
         }
     </script>

--- a/publication_manifest/manifest_processing/tests/test_m6.04.html
+++ b/publication_manifest/manifest_processing/tests/test_m6.04.html
@@ -12,6 +12,9 @@
             "conformsTo": "https://www.w3.org/TR/pub-manifest/",
             "readingOrder": [
                 "chapter1.html"
+            ],
+            "resources": [
+                "test_m6.04.html"
             ]
         }
     </script>

--- a/publication_manifest/manifest_processing/tests/test_m6.06.html
+++ b/publication_manifest/manifest_processing/tests/test_m6.06.html
@@ -11,6 +11,9 @@
             "conformsTo": "https://www.w3.org/TR/pub-manifest/",
             "readingOrder": [
                 "chapter1.html"
+            ],
+            "resources": [
+                "test_m6.06.html"
             ]
         }
     </script>

--- a/publication_manifest/manifest_processing/tests/test_m6.07.html
+++ b/publication_manifest/manifest_processing/tests/test_m6.07.html
@@ -9,16 +9,14 @@
             "type": "CreativeWork",
             "id" : "urn:isbn:1234567890",
             "url": "https://example.org/book",
-            "conformsTo": "https://www.w3.org/TR/pub-manifest/",
-            "readingOrder": [
-                "test_m6.07.html"
-            ]
+            "conformsTo": "https://www.w3.org/TR/pub-manifest/"
         }
-    </script>
+        "readingOrder": [
+            "chapter1.html"
+        ]
+</script>
 </head>
 <body>
-    <h1>This is a single document publication</h1>
-
-    <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Sint fuga soluta vero fugiat nobis suscipit asperiores natus laudantium reprehenderit consectetur eius modi repellendus quam tempora ea, ut, iusto veritatis ex.</p>
+    <p>This is just a fake entry point.</p>
 </body>
 </html>

--- a/publication_manifest/manifest_processing/tests/test_m6.07.html
+++ b/publication_manifest/manifest_processing/tests/test_m6.07.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<head>
+    <title>Single document publication</title>
+    <link rel="publication" href="#manifest" />
+    <script id='manifest' type='application/ld+json'>
+        {
+            "@context" : ["https://schema.org", "https://www.w3.org/ns/pub-context"],
+            "type": "CreativeWork",
+            "id" : "urn:isbn:1234567890",
+            "url": "https://example.org/book",
+            "conformsTo": "https://www.w3.org/TR/pub-manifest/",
+            "readingOrder": [
+                "test_m6.07.html"
+            ]
+        }
+    </script>
+</head>
+<body>
+    <h1>This is a single document publication</h1>
+
+    <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Sint fuga soluta vero fugiat nobis suscipit asperiores natus laudantium reprehenderit consectetur eius modi repellendus quam tempora ea, ut, iusto veritatis ex.</p>
+</body>
+</html>

--- a/publication_manifest/manifest_processing/tests/test_m6.08.html
+++ b/publication_manifest/manifest_processing/tests/test_m6.08.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Entry point with linked manifest</title>
+    <link rel="publication" href="link6.08.jsonld" />
+</head>
+<body>
+    <p>This is just a fake entry point with a fake content.</p>
+</body>
+</html>

--- a/publication_manifest/toc_processing/tests/c2.branches.01.html
+++ b/publication_manifest/toc_processing/tests/c2.branches.01.html
@@ -37,7 +37,8 @@
       "url": "http://ia800704.us.archive.org/9/items/LibrivoxCdCoverArt12/Flatland_1109.jpg",
       "encodingFormat": "image/jpeg",
       "name": "Cover page with title and author"
-    }
+    },
+    "c2.branches.01.html"
   ],
   "readingOrder": [
     {

--- a/publication_manifest/toc_processing/tests/c2.branches.02.html
+++ b/publication_manifest/toc_processing/tests/c2.branches.02.html
@@ -37,7 +37,8 @@
       "url": "http://ia800704.us.archive.org/9/items/LibrivoxCdCoverArt12/Flatland_1109.jpg",
       "encodingFormat": "image/jpeg",
       "name": "Cover page with title and author"
-    }
+    },
+    "c2.branches.02.html"
   ],
   "readingOrder": [
     {

--- a/publication_manifest/toc_processing/tests/c2.branches.03.html
+++ b/publication_manifest/toc_processing/tests/c2.branches.03.html
@@ -37,7 +37,8 @@
       "url": "http://ia800704.us.archive.org/9/items/LibrivoxCdCoverArt12/Flatland_1109.jpg",
       "encodingFormat": "image/jpeg",
       "name": "Cover page with title and author"
-    }
+    },
+    "c2.branches.03.html"
   ],
   "readingOrder": [
     {

--- a/publication_manifest/toc_processing/tests/c2.branches.04.html
+++ b/publication_manifest/toc_processing/tests/c2.branches.04.html
@@ -37,7 +37,8 @@
       "url": "http://ia800704.us.archive.org/9/items/LibrivoxCdCoverArt12/Flatland_1109.jpg",
       "encodingFormat": "image/jpeg",
       "name": "Cover page with title and author"
-    }
+    },
+    "c2.branches.04.html"
   ],
   "readingOrder": [
     {

--- a/publication_manifest/toc_processing/tests/c2.branches.05.html
+++ b/publication_manifest/toc_processing/tests/c2.branches.05.html
@@ -37,7 +37,8 @@
       "url": "http://ia800704.us.archive.org/9/items/LibrivoxCdCoverArt12/Flatland_1109.jpg",
       "encodingFormat": "image/jpeg",
       "name": "Cover page with title and author"
-    }
+    },
+    "c2.branches.05.html"
   ],
   "readingOrder": [
     {

--- a/publication_manifest/toc_processing/tests/c2.branches.06.html
+++ b/publication_manifest/toc_processing/tests/c2.branches.06.html
@@ -37,7 +37,8 @@
       "url": "http://ia800704.us.archive.org/9/items/LibrivoxCdCoverArt12/Flatland_1109.jpg",
       "encodingFormat": "image/jpeg",
       "name": "Cover page with title and author"
-    }
+    },
+    "c2.branches.06.html"
   ],
   "readingOrder": [
     {

--- a/publication_manifest/toc_processing/tests/c2.branches.07.html
+++ b/publication_manifest/toc_processing/tests/c2.branches.07.html
@@ -37,7 +37,8 @@
       "url": "http://ia800704.us.archive.org/9/items/LibrivoxCdCoverArt12/Flatland_1109.jpg",
       "encodingFormat": "image/jpeg",
       "name": "Cover page with title and author"
-    }
+    },
+    "c2.branches.07.html"
   ],
   "readingOrder": [
     {

--- a/publication_manifest/toc_processing/tests/c2.branches.08.html
+++ b/publication_manifest/toc_processing/tests/c2.branches.08.html
@@ -37,7 +37,8 @@
       "url": "http://ia800704.us.archive.org/9/items/LibrivoxCdCoverArt12/Flatland_1109.jpg",
       "encodingFormat": "image/jpeg",
       "name": "Cover page with title and author"
-    }
+    },
+    "c2.branches.08.html"
   ],
   "readingOrder": [
     {

--- a/publication_manifest/toc_processing/tests/c2.ignored.01.html
+++ b/publication_manifest/toc_processing/tests/c2.ignored.01.html
@@ -38,7 +38,8 @@
       "url": "http://ia800704.us.archive.org/9/items/LibrivoxCdCoverArt12/Flatland_1109.jpg",
       "encodingFormat": "image/jpeg",
       "name": "Cover page with title and author"
-    }
+    },
+    "c2.ignored.01.html"
   ],
   "readingOrder": [
     {

--- a/publication_manifest/toc_processing/tests/c2.ignored.02.html
+++ b/publication_manifest/toc_processing/tests/c2.ignored.02.html
@@ -38,7 +38,8 @@
       "url": "http://ia800704.us.archive.org/9/items/LibrivoxCdCoverArt12/Flatland_1109.jpg",
       "encodingFormat": "image/jpeg",
       "name": "Cover page with title and author"
-    }
+    },
+    "c2.ignored.02.html"
   ],
   "readingOrder": [
     {

--- a/publication_manifest/toc_processing/tests/c2.ignored.03.html
+++ b/publication_manifest/toc_processing/tests/c2.ignored.03.html
@@ -38,7 +38,8 @@
       "url": "http://ia800704.us.archive.org/9/items/LibrivoxCdCoverArt12/Flatland_1109.jpg",
       "encodingFormat": "image/jpeg",
       "name": "Cover page with title and author"
-    }
+    },
+    "c2.ignored.03.html"
   ],
   "readingOrder": [
     {

--- a/publication_manifest/toc_processing/tests/c2.ignored.04.html
+++ b/publication_manifest/toc_processing/tests/c2.ignored.04.html
@@ -38,7 +38,8 @@
       "url": "http://ia800704.us.archive.org/9/items/LibrivoxCdCoverArt12/Flatland_1109.jpg",
       "encodingFormat": "image/jpeg",
       "name": "Cover page with title and author"
-    }
+    },
+    "c2.ignored.04.html"
   ],
   "readingOrder": [
     {

--- a/publication_manifest/toc_processing/tests/c2.ignored.05.html
+++ b/publication_manifest/toc_processing/tests/c2.ignored.05.html
@@ -38,7 +38,8 @@
       "url": "http://ia800704.us.archive.org/9/items/LibrivoxCdCoverArt12/Flatland_1109.jpg",
       "encodingFormat": "image/jpeg",
       "name": "Cover page with title and author"
-    }
+    },
+    "c2.ignored.05.html"
   ],
   "readingOrder": [
     {

--- a/publication_manifest/toc_processing/tests/c2.list.01.html
+++ b/publication_manifest/toc_processing/tests/c2.list.01.html
@@ -38,7 +38,8 @@
       "url": "http://ia800704.us.archive.org/9/items/LibrivoxCdCoverArt12/Flatland_1109.jpg",
       "encodingFormat": "image/jpeg",
       "name": "Cover page with title and author"
-    }
+    },
+    "c2.list.01.html"
   ],
   "readingOrder": [
     {

--- a/publication_manifest/toc_processing/tests/c2.list.02.html
+++ b/publication_manifest/toc_processing/tests/c2.list.02.html
@@ -38,7 +38,8 @@
       "url": "http://ia800704.us.archive.org/9/items/LibrivoxCdCoverArt12/Flatland_1109.jpg",
       "encodingFormat": "image/jpeg",
       "name": "Cover page with title and author"
-    }
+    },
+    "c2.list.02.html"
   ],
   "readingOrder": [
     {

--- a/publication_manifest/toc_processing/tests/c2.skipped.01.html
+++ b/publication_manifest/toc_processing/tests/c2.skipped.01.html
@@ -38,7 +38,8 @@
       "url": "http://ia800704.us.archive.org/9/items/LibrivoxCdCoverArt12/Flatland_1109.jpg",
       "encodingFormat": "image/jpeg",
       "name": "Cover page with title and author"
-    }
+    },
+	"c2.skipped.01.html"
   ],
   "readingOrder": [
     {

--- a/publication_manifest/toc_processing/tests/c2.skipped.02.html
+++ b/publication_manifest/toc_processing/tests/c2.skipped.02.html
@@ -38,7 +38,8 @@
       "url": "http://ia800704.us.archive.org/9/items/LibrivoxCdCoverArt12/Flatland_1109.jpg",
       "encodingFormat": "image/jpeg",
       "name": "Cover page with title and author"
-    }
+    },
+	"c2.skipped.02.html"
   ],
   "readingOrder": [
     {

--- a/publication_manifest/toc_processing/tests/c2.skipped.03.html
+++ b/publication_manifest/toc_processing/tests/c2.skipped.03.html
@@ -38,7 +38,8 @@
       "url": "http://ia800704.us.archive.org/9/items/LibrivoxCdCoverArt12/Flatland_1109.jpg",
       "encodingFormat": "image/jpeg",
       "name": "Cover page with title and author"
-    }
+    },
+    "c2.skipped.03.html"
   ],
   "readingOrder": [
     {

--- a/publication_manifest/toc_processing/tests/c2.title.01.html
+++ b/publication_manifest/toc_processing/tests/c2.title.01.html
@@ -37,7 +37,9 @@
       "url": "http://ia800704.us.archive.org/9/items/LibrivoxCdCoverArt12/Flatland_1109.jpg",
       "encodingFormat": "image/jpeg",
       "name": "Cover page with title and author"
-    }
+    },
+    "c2.title.01.html"
+
   ],
   "readingOrder": [
     {

--- a/publication_manifest/toc_processing/tests/c2.title.02.html
+++ b/publication_manifest/toc_processing/tests/c2.title.02.html
@@ -38,7 +38,8 @@
       "url": "http://ia800704.us.archive.org/9/items/LibrivoxCdCoverArt12/Flatland_1109.jpg",
       "encodingFormat": "image/jpeg",
       "name": "Cover page with title and author"
-    }
+    },
+    "c2.title.02.html"
   ],
   "readingOrder": [
     {

--- a/publication_manifest/toc_processing/tests/c2.title.03.html
+++ b/publication_manifest/toc_processing/tests/c2.title.03.html
@@ -38,7 +38,8 @@
       "url": "http://ia800704.us.archive.org/9/items/LibrivoxCdCoverArt12/Flatland_1109.jpg",
       "encodingFormat": "image/jpeg",
       "name": "Cover page with title and author"
-    }
+    },
+    "c2.title.03.html"
   ],
   "readingOrder": [
     {

--- a/publication_manifest/toc_processing/tests/c2.title.04.html
+++ b/publication_manifest/toc_processing/tests/c2.title.04.html
@@ -38,7 +38,8 @@
       "url": "http://ia800704.us.archive.org/9/items/LibrivoxCdCoverArt12/Flatland_1109.jpg",
       "encodingFormat": "image/jpeg",
       "name": "Cover page with title and author"
-    }
+    },
+    "c2.title.04.html"
   ],
   "readingOrder": [
     {

--- a/publication_manifest/toc_processing/tests/s4.8.1.3.06.html
+++ b/publication_manifest/toc_processing/tests/s4.8.1.3.06.html
@@ -38,7 +38,8 @@
       "url": "http://ia800704.us.archive.org/9/items/LibrivoxCdCoverArt12/Flatland_1109.jpg",
       "encodingFormat": "image/jpeg",
       "name": "Cover page with title and author"
-    }
+    },
+    "s4.8.1.3.06.html"    
   ],
   "readingOrder": [
     {

--- a/publication_manifest/toc_processing/tests/s4.8.1.3.07.html
+++ b/publication_manifest/toc_processing/tests/s4.8.1.3.07.html
@@ -38,7 +38,8 @@
       "url": "http://ia800704.us.archive.org/9/items/LibrivoxCdCoverArt12/Flatland_1109.jpg",
       "encodingFormat": "image/jpeg",
       "name": "Cover page with title and author"
-    }
+    },
+    "s4.8.1.3.07.html"
   ],
   "readingOrder": [
     {

--- a/publication_manifest/toc_processing/tests/s4813-01/publication.jsonld
+++ b/publication_manifest/toc_processing/tests/s4813-01/publication.jsonld
@@ -35,7 +35,8 @@
       "rel": "contents",
       "url": "toc.html",
       "encodingFormat": "text/html"
-    }
+    },
+    "../s4.8.1.3.01.html"
   ],
   "readingOrder": [
     {

--- a/publication_manifest/toc_processing/tests/s4813-02/publication.jsonld
+++ b/publication_manifest/toc_processing/tests/s4813-02/publication.jsonld
@@ -26,12 +26,13 @@
   "accessibilitySummary": "This is just a test summary",
   "readingProgression": "ltr",
   "resources": [
-	{
+	  {
       "rel": "cover",
       "url": "http://ia800704.us.archive.org/9/items/LibrivoxCdCoverArt12/Flatland_1109.jpg",
       "encodingFormat": "image/jpeg",
       "name": "Cover page with title and author"
-    }
+    },
+    "../s4.8.1.3.02.html"
   ],
   "readingOrder": [
     {

--- a/publication_manifest/toc_processing/tests/s4813-03/publication.jsonld
+++ b/publication_manifest/toc_processing/tests/s4813-03/publication.jsonld
@@ -31,7 +31,8 @@
       "url": "http://ia800704.us.archive.org/9/items/LibrivoxCdCoverArt12/Flatland_1109.jpg",
       "encodingFormat": "image/jpeg",
       "name": "Cover page with title and author"
-    }
+    },
+    "../s4.8.1.3.03.html"
   ],
   "readingOrder": [
     {

--- a/publication_manifest/toc_processing/tests/s4813-04/publication.jsonld
+++ b/publication_manifest/toc_processing/tests/s4813-04/publication.jsonld
@@ -35,7 +35,8 @@
       "rel": "contents",
       "url": "toc.html",
       "encodingFormat": "text/html"
-    }
+    },
+    "../s4.8.1.3.04.html"
   ],
   "readingOrder": [
     {

--- a/publication_manifest/toc_processing/tests/s4813-05/publication.jsonld
+++ b/publication_manifest/toc_processing/tests/s4813-05/publication.jsonld
@@ -35,7 +35,8 @@
       "rel": "contents",
       "url": "toc.html#toc",
       "encodingFormat": "text/html"
-    }
+    },
+    "../s4.8.1.3.05.html"
   ],
   "readingOrder": [
     {


### PR DESCRIPTION
Updated tests in line of https://github.com/w3c/pub-manifest/pull/199: all tests include the PEP reference in resources.

The PR also includes some new tests related to https://github.com/w3c/pub-manifest/pull/199, as well as the updated report for my own implementation that are ok with those tests, too