### PR TITLE
Adding section for publisher implementations

### DIFF
--- a/test_reports/content_implementations/index.html
+++ b/test_reports/content_implementations/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8" />
+    <title>
+        Implementation Report for the Processing of Publication and Audiobooks Manifests
+    </title>
+    <link href='https://www.w3.org/StyleSheets/TR/base' rel='stylesheet'/>
+    <link href='common/css/style.css' rel='stylesheet'/>
+</head>
+<body>
+  <header>
+      <p>
+          <a href='http://www.w3.org/'>
+              <img alt='W3C' height='48' src='https://www.w3.org/Icons/w3c_home' width='72' />
+          </a>
+      </p>
+      <h1>
+          Implementation Report for the Content Creator Submissions.
+      </h1>
+      <nav role='doc-toc' data-options='dynamic max_depth=3 use_sections'></nav>
+  </header>
+  <main>
+    <p>The following content creators have used <a href="https://w3c.github.io/pub-manifest/">Publication Manifest</a> or <a href="https://w3c.github.io/audiobooks/">Audiobooks</a> to create content for internal use or public/commercial distribution. Where possible, this content has been tested against some of the implementations mentioned in the <a href="../manifest_processing/index.html">Implementation Report</a>. Any produced content that is released for testing can be found in the <code>test_content</code> folder in our <a href="https://github.com/w3c/publ-tests">GitHub</a> repository.</p>
+
+    <p>Please note that a content creator may be listed here and may not share their content publicly, all content creators listed will be confirmed by the chairs and editors of the Publishing Working Group.</p>
+
+    <section id="content_creators">
+      <h2>Content Creators using Publication Manifest/Audiobooks</h2>
+
+      <ol>
+        <li>TBD</li>
+      </ol>
+    </section>
+  </main>
+</body>
+</html>

--- a/test_reports/manifest_processing/index.html
+++ b/test_reports/manifest_processing/index.html
@@ -120,7 +120,30 @@
                   </tbody>
                 </table>
               </section>
-            </section> -->
+            </section>
+        </section>-->
+
+        <section id="publisher_implementations">
+          <h3>Content Creator Implementations</h3>
+
+          <p>This section covers the implementations that have been submitted by content creators. This implementations are limited to the production of publication manifest files or audiobooks manifests, not user agents. Where possible, they have been tested by an existing implementation.</p>
+          <dl id="publisher_implementations">
+          </dl>
+
+          <section>
+            <h4>Test Results Overview</h4>
+            <table id="publisher_implementations" class="zebra">
+              <thead>
+                <tr id="publisher_implementations_table_row">
+                  <th>No.</th>
+                  <th>Test</th>
+                  <th>Description</th>
+                </tr>
+              </thead>
+              <tbody id="publisher_implementations_table_body">
+              </tbody>
+            </table>
+          </section>
         </section>
 
         <section id='test_descriptions'>
@@ -153,7 +176,7 @@
                     </li>
                     <li>Put the new report file into the <code>publication_manifest/manifest_processing/reports/</code> (respectively <code>audiobooks/manifest_processing/reports/</code>) folder (use, preferably the name of the implementation as file name for an easier management).</li>
                     <li>Modify the <a href="../../publication_manifest/manifest_processing/reports/index.json"><code>index.json</code> file in the general manifest processing</a> (respectively <a href="../../audiobooks/manifest_processing/reports/index.json">in the the audiobook manifest processing</a>) folder by adding the file name of the report file without the extension.</li>
-                </ol>        
+                </ol>
             </section>
             <section>
                 <h2>Modifying an existing implementation report</h2>

--- a/test_reports/manifest_processing/index.html
+++ b/test_reports/manifest_processing/index.html
@@ -123,7 +123,7 @@
             </section>
         </section>-->
 
-        <section id="publisher_implementations">
+        <!-- <section id="publisher_implementations">
           <h3>Content Creator Implementations</h3>
 
           <p>This section covers the implementations that have been submitted by content creators. This implementations are limited to the production of publication manifest files or audiobooks manifests, not user agents. Where possible, they have been tested by an existing implementation.</p>
@@ -144,7 +144,7 @@
               </tbody>
             </table>
           </section>
-        </section>
+        </section> -->
 
         <section id='test_descriptions'>
             <h2>Description of the individual tests</h2>


### PR DESCRIPTION
As mentioned in the last call, adding a section for publisher implementations. Not sure how to hook it into the tests if needed though @iherman let me know and I can do it! 