### PR TITLE
Added the LPF reporting to the system

### DIFF
--- a/lpf/package_processing/tests/index.json
+++ b/lpf/package_processing/tests/index.json
@@ -1,11 +1,11 @@
 {
   "date": "2020-01-05",
   "title": "Tests related to LPF processing",
-  "href": "https://www.w3.org/TR/2019/NOTE-lpf-20191205/",
+  "href": "https://www.w3.org/TR/2020/NOTE-lpf-20200319/",
   "tests": [
       {
           "section": "§4 Packaging format",
-          "href": "https://www.w3.org/TR/2019/NOTE-lpf-20191205/#sec-zip",
+          "href": "https://www.w3.org/TR/2020/NOTE-lpf-20200319/#sec-zip",
           "tests": [
               {
                   "id": "t4.01",
@@ -19,7 +19,7 @@
       },
       {
           "section": "§5. Compression of resources",
-          "href": "https://www.w3.org/TR/2019/NOTE-lpf-20191205/#sec-compression",
+          "href": "https://www.w3.org/TR/2020/NOTE-lpf-20200319/#sec-compression",
           "tests": [
               {
                   "id": "t5.01",
@@ -39,7 +39,7 @@
       },
       {
           "section": "§6 File and directory structure",
-          "href": "https://www.w3.org/TR/2019/NOTE-lpf-20191205/#sec-structure",
+          "href": "https://www.w3.org/TR/2020/NOTE-lpf-20200319/#sec-structure",
           "tests": [
               {
                   "id": "t6.01",
@@ -94,7 +94,7 @@
       },
       {
           "section": "§7 Obtaining a publication manifest",
-          "href": "https://www.w3.org/TR/2019/NOTE-lpf-20191205/#sec-obtaining-manifest",
+          "href": "https://www.w3.org/TR/2020/NOTE-lpf-20200319/#sec-obtaining-manifest",
           "tests": [
               {
                   "id": "t7.01",

--- a/test_reports/README.md
+++ b/test_reports/README.md
@@ -3,4 +3,5 @@
 - [Implementation Report for the Processing of Publication and Audiobooks Manifests](https://w3c.github.io/publ-tests/test_reports/manifest_processing/index.html).
 - [Implementation report for the Processing of Table of Contents](https://w3c.github.io/publ-tests/test_reports/toc_processing/). (This section of the specification is non normative.)
 - [Implementation report for Audiobooks User Agent Behavior tests](https://w3c.github.io/publ-tests/test_reports/ua_behaviours/). (This section of the specification is non normative.)
+- [Implementation report for Lightweight Packaging tests](https://w3c.github.io/publ-tests/test_reports/lpf/). (This specification is a Working Group Note.)
 - [Publication Manifest to EPUB Mapping Report](https://w3c.github.io/publ-tests/test_reports/epub_mapping/index.html). (This section of the specification is non normative.)

--- a/test_reports/lpf/README.md
+++ b/test_reports/lpf/README.md
@@ -1,0 +1,3 @@
+# Implementation Report for the Processing of Lightweight Packaging (LPF)
+
+- [Report in HTML](https://w3c.github.io/publ-tests/test_reports/lpf/).

--- a/test_reports/lpf/index.html
+++ b/test_reports/lpf/index.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8" />
+		<title>Implementation Report for the Processing of Lightweight Packaging</title>
+		<link href="https://www.w3.org/StyleSheets/TR/base" rel="stylesheet" />
+		<link href="../manifest_processing/common/css/style.css" rel="stylesheet" />
+		<script src="../manifest_processing/common/js/display_scores.js"></script>
+		<script src="../common/js/doc-toc.js"></script>
+		<script>
+        const tests = [{
+            test_index: '../../lpf/package_processing/tests/index.json',
+			impl_index: '../../lpf/package_processing/reports/index.json',
+			prefix: 'lpf'
+        }];
+
+        async function display() {
+            tests.forEach((block) => {
+                const dummy = display_test_suite(block);
+            })
+            // Generate the TOC
+            handleDocToc();
+        }
+        window.addEventListener('load', display);   
+    </script>
+	</head>
+
+	<body>
+		<header>
+			<p>
+				<a href="http://www.w3.org/">
+					<img alt="W3C" height="48" src="https://www.w3.org/Icons/w3c_home" width="72" />
+				</a>
+			</p>
+			<h1> Implementation Report for the Processing of Lightweight Packaging </h1>
+			<nav role="doc-toc" data-options="dynamic max_depth=3 use_sections"></nav>
+		</header>
+		<main>
+			<p>These tests, and the implementation report, refer to the <a
+					href="https://www.w3.org/TR/2019/NOTE-lpf-20191205/">“Lightweight Packaging Format”</a>
+				specification.</p>
+
+			<section>
+				<h2>Test results</h2>
+
+				<p>The implementations that have been submitted for this report are:</p>
+
+				<dl id="lpf_implementations"> </dl>
+
+				<section>
+					<h4>Test results overview</h4>
+					<table id="lpf_results" class="zebra">
+						<thead>
+							<tr id="lpf_header_row">
+								<th>No.</th>
+								<th>Test</th>
+								<th>Description</th>
+							</tr>
+						</thead>
+						<tbody id="lpf_table_body"> </tbody>
+					</table>
+				</section>
+			</section>
+
+			<section id="lpf_tests">
+				<h2>Description of the individual tests</h2>
+			</section>
+
+			<section>
+				<h2>Contributing to the reports</h2>
+				<p>The actions below are described as adding/modifying files; this should be understood as changes on
+					submitter’s own copy which should then be submitted, via a Pull Request, to the test repository.</p>
+				<section>
+					<h3>Adding a new implementation report</h3>
+					<ol>
+						<li>Create a new JSON report file. The file format is simple: <ul>
+								<li>a field <code>$name</code> with, as value, the name of the implementation (will be
+									used as the column label for the results;</li>
+								<li>a field <code>$description</code> with, as value, the short description of the
+									implementation;</li>
+								<li>an optional field <code>$href</code> with, as value, a URL to the implementation
+									page;</li>
+								<li>for each implemented test add a field with the test code and a boolean value on
+									whether the test is passed or not (remove the entry if it was not used for
+									testing).</li>
+							</ul>
+						</li>
+						<li>Put the new report file into the <code>publication_manifest/toc_processing/reports/</code> folder (use, preferably the name of
+							the implementation as file name for an easier management).</li>
+						<li>Modify the <a href="../../lpf/package_processing/tests/index.json"><code>index.json</code></a> by adding
+							the file name of the report file without the extension.</li>
+					</ol>
+				</section>
+				<section>
+					<h2>Modifying an existing implementation report</h2>
+					<p>Provide a new pull request for the updated implementation JSON file.</p>
+				</section>
+				<section>
+					<h3>Adding a new test</h3>
+					<ol>
+						<li>Add the new test to the <code>publication_manifest/toc_processing/tests/</code> directory in
+							this repository following the numbering scheme used in the current tests for the names.</li>
+						<li>Extend the <a href="../../lpf/package_processing/tests/index.json"
+									><code>index.json</code></a> file
+							with the relevant information.</li>
+					</ol>
+				</section>
+			</section>
+		</main>
+	</body>
+</html>


### PR DESCRIPTION
**This is a PR for the `thorium-reader` branch**!

@llemeurfr, I did not want to commit directly into the `thorium-reader` branch; this may have messed up your processing. If you think it is fine, you can merge it into that branch, and it could then be merged, eventually, into the `master` branch.

This PR adds the reporting to the LPF results to the system and links it from the overall test results page. Two comments, though:

- The test suite refers to a series of tests, but they are not on the repository, as far as I can see (they should be in `lpf/package_processing/tests`). @llmeurfr, I presume you will push them to the repo with the final test results.
- The test suite index refers to the tests with names such as `t4.01`, `t5.01`, etc. whereas the ThoriumReader test results refer to the tests as `l4.01`, l5.01`, etc. As a result, the report reports for all tests as a `n/a`. As this is the first report on the LPF tests, this can be either way, but should be consistent... I did not do any change on this in the current PR, I leave the choice to you, @llmeurfr.

Thanks! 