### PR TITLE
Fix m4.7.2.2.03 test actions

### DIFF
--- a/publication_manifest/manifest_processing/tests/index.json
+++ b/publication_manifest/manifest_processing/tests/index.json
@@ -442,7 +442,7 @@
                 {
                     "id": "m4.7.2.2.03",
                     "description": "Duplicate URLs generate warning but stay in 'resources''",
-                    "actions": "The third entry in 'resources' is removed from the final list",
+                    "actions": "The output does not change",
                     "errors": "Validation error on repeated resources",
                     "media-type": "application/ld+json"
                 }


### PR DESCRIPTION
Currently, the actions description states:

> The third entry in 'resources' is removed from the final list

Which contradicts to the test's description, which says:

> Duplicate URLs generate warning but stay in 'resources'