### PR TITLE
Fix s4.8.1.3.06/07 test fixtures

### DIFF
--- a/publication_manifest/toc_processing/tests/s4.8.1.3.06.html
+++ b/publication_manifest/toc_processing/tests/s4.8.1.3.06.html
@@ -4,7 +4,7 @@
 		<title>Hidden table of contents</title>
 		<link rel="publication" href="#manifest">
 		<link rel="stylesheet" href="css/basic.css">
-		<script id="manifest">
+		<script id="manifest" type="application/ld+json">
 {
   "@context": [
       "https://schema.org",

--- a/publication_manifest/toc_processing/tests/s4.8.1.3.07.html
+++ b/publication_manifest/toc_processing/tests/s4.8.1.3.07.html
@@ -4,7 +4,7 @@
 		<title>Table of Contents not in a nav element</title>
 		<link rel="publication" href="#manifest">
 		<link rel="stylesheet" href="css/basic.css">
-		<script id="manifest">
+		<script id="manifest" type="application/ld+json">
 {
   "@context": [
       "https://schema.org",


### PR DESCRIPTION
From https://www.w3.org/TR/pub-manifest/#manifest-embed:

> When a digital publication format allows manifests to be embedded within an HTML document, the manifest *MUST* be included in a `script` element whose `type` attribute is set to `application/ld+json`.