### PR TITLE
Fix c2.ignored.03 test actions

### DIFF
--- a/publication_manifest/toc_processing/tests/index.json
+++ b/publication_manifest/toc_processing/tests/index.json
@@ -229,7 +229,7 @@
 				{
 					"id": "c2.ignored.03",
 					"description": "TOC branch with list of ignored elements",
-					"actions": "Table of contents is null",
+					"actions": "TOC with a single link to Part 1",
 					"errors": "none",
 					"media-type": "text/html"
 				},


### PR DESCRIPTION
In my understanding, this test should produce a TOC with a single entry to _Part 1_, as shown in the test HTML document:

https://github.com/w3c/publ-tests/blob/4f8bd4c17f78e821032f55541f36eda6cac1cf6c/publication_manifest/toc_processing/tests/c2.ignored.03.html#L76-L90